### PR TITLE
Route Plugin Added to Extensions Page

### DIFF
--- a/07-extensions/02-plugins.md
+++ b/07-extensions/02-plugins.md
@@ -26,6 +26,7 @@
 * [Poll](http://github.com/chroposnos/poll) by Israel Segundo
 * [Poll](http://github.com/primeminister/poll) by Zijad Redžić and Charlie van de Kerkhof
 * [Resume](https://github.com/thoth/resume) by Thomas Rader
+* [Route] (https://github.com/deplorable/Croogo_Plugins_Route) by Damian Grant
 * [Sites](https://github.com/rchavik/sites) by Rachman Chavik
 * [Sitemap](http://github.com/traedamatic/croogo_sitemap_plugin) by Nicolas Traeder
 * [Social Bookmarks](http://github.com/fahad19/social_bookmarks) by Fahad Ibnay Heylaal


### PR DESCRIPTION
Hi Fahad, 
I added the Route plugin from : http://github.com/deplorable/Croogo_Plugins_Route
to the list on your extensions page.
Thanks for your help - much appreciated, :)
Damian.
