### PR TITLE
1.4 plugins for wiki documentation

### DIFF
--- a/en/extensions/plugins.md
+++ b/en/extensions/plugins.md
@@ -1,5 +1,10 @@
 # Plugins
 
+#### Compatible with Croogo 1.4:
+
+* [Megamenu](https://github.com/rchavik/megamenu) by Rachman Chavik
+* [Route](https://github.com/deplorable/Croogo_Plugins_Route) by Damian Grant
+
 #### Compatible with Croogo 1.3.2 or higher:
 
 * [Advertising](http://github.com/chroposnos/Advertising-Croogo-Plugin) by Israel Segundo


### PR DESCRIPTION
Hi Fahad,

Have just updated the plugin page with links to two extensions for Croogo 1.4. Not sure if you want 1.4 plugins on the Wiki at this stage or not - please tell me if you'd prefer to hold back until more development on 1.4 is completed. 

Cheers!

Damian.
