### PR TITLE
Update en/1.4/migration-guide/index.md

### DIFF
--- a/en/1.4/migration-guide/index.md
+++ b/en/1.4/migration-guide/index.md
@@ -3,7 +3,7 @@
 It goes without saying that you should keep a fully backed-up copy of your
 database and web directory.
 
-- Check the [system requirement](../getting-started/requirements)
+- Check the [system requirements](../1.4/getting-started/requirements)
 
 - `Config/core.php`
 


### PR DESCRIPTION
Fix requirements link

Note: This fixes it as a relative link on /1.4/migration-guide. This is
how the Migration Guide is linked from the 1.4 page and the sidebar
menu. However, the relative link would be invalid if the Migration
Guide is linked as /1.4/migration-guide/ (with the ending slash). I'm
not sure how to fix it for both.
