### PR TITLE
Update en/1.4/getting-started/demo.md

### DIFF
--- a/en/1.4/getting-started/demo.md
+++ b/en/1.4/getting-started/demo.md
@@ -1,9 +1,9 @@
 # Demo
 
-[WebbedIT](http://www.webbedit.co.uk/) have a hosted demo of Croogo using Cake
-2.0.5 and a clone of the 1.4 GitHub branch as of 22nd Jan 2012.
+[WebbedIT](http://www.webbedit.co.uk/) have a hosted demo of Croogo using latest Cake
+(v2.2.4) and a clone of the master Croogo branch (v1.4.3) taken 7th Dec 2012.
 
-* [Frontend](http://croogo.webbedit.co.uk)
-* [Admin Panel](http://croogo.webbedit.co.uk/admin)
+* [Frontend](http://croogo.webbedit.co.uk/demo14)
+* [Admin Panel](http://croogo.webbedit.co.uk/demo14/admin)
    * **Username**: admin
    * **Password**: demo123


### PR DESCRIPTION
I was cleaning my server up the other day and deleted the 
croogo.webbedit.co.uk domain forgetting why it existed, oops! Sorry!

Have restored the demo, updated CakePHP to 2.2.4 and pulled the 
latest master Croogo branch.  

Just updating the documentation as moved the demo into a subfolder 
so I can also host a demo of the 1.5 branch when it's ready. 
